### PR TITLE
Rename Compression to Compressor and so on.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ os:
 julia:
   - 0.6
   - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 notifications:
   email: false
 # uncomment the following lines to override the default test script
@@ -14,4 +17,4 @@ notifications:
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("CodecZlib"); Pkg.test("CodecZlib"; coverage=true)'
 after_success:
   # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("CodecZlib")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - if [ $TRAVIS_JULIA_VERSION != "nightly" ]; then julia -e 'cd(Pkg.dir("CodecZlib")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/README.md
+++ b/README.md
@@ -27,28 +27,28 @@ erat ex bibendum ipsum, sed varius ipsum ipsum vitae dui.
 """
 
 # Streaming API.
-stream = GzipCompressionStream(IOBuffer(text))
-for line in eachline(GzipDecompressionStream(stream))
+stream = GzipCompressorStream(IOBuffer(text))
+for line in eachline(GzipDecompressorStream(stream))
     println(line)
 end
 close(stream)
 
 # Array API.
-compressed = transcode(GzipCompression(), text)
+compressed = transcode(GzipCompressor(), text)
 @assert sizeof(compressed) < sizeof(text)
-@assert transcode(GzipDecompression(), compressed) == Vector{UInt8}(text)
+@assert transcode(GzipDecompressor(), compressed) == Vector{UInt8}(text)
 ```
 
 This package exports following codecs and streams:
 
 | Codec                  | Stream                       |
 | ---------------------- | ---------------------------- |
-| `GzipCompression`      | `GzipCompressionStream`      |
-| `GzipDecompression`    | `GzipDecompressionStream`    |
-| `ZlibCompression`      | `ZlibCompressionStream`      |
-| `ZlibDecompression`    | `ZlibDecompressionStream`    |
-| `DeflateCompression`   | `DeflateCompressionStream`   |
-| `DeflateDecompression` | `DeflateDecompressionStream` |
+| `GzipCompressor`      | `GzipCompressorStream`      |
+| `GzipDecompressor`    | `GzipDecompressorStream`    |
+| `ZlibCompressor`      | `ZlibCompressorStream`      |
+| `ZlibDecompressor`    | `ZlibDecompressorStream`    |
+| `DeflateCompressor`   | `DeflateCompressorStream`   |
+| `DeflateDecompressor` | `DeflateDecompressorStream` |
 
 See docstrings and [TranscodingStreams.jl](https://github.com/bicycle1885/TranscodingStreams.jl) for details.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Pkg.add("CodecZlib")
 
 ## Usage
 
+**Note**: `GzipCompression`, `GzipDecompressionStream`, etc. are deprecated. Use
+`GzipCompressor`, `GzipDecompressorStream`, etc. instead.
+
 ```julia
 using CodecZlib
 
@@ -34,21 +37,21 @@ end
 close(stream)
 
 # Array API.
-compressed = transcode(GzipCompressor(), text)
+compressed = transcode(GzipCompressor, text)
 @assert sizeof(compressed) < sizeof(text)
-@assert transcode(GzipDecompressor(), compressed) == Vector{UInt8}(text)
+@assert transcode(GzipDecompressor, compressed) == Vector{UInt8}(text)
 ```
 
 This package exports following codecs and streams:
 
 | Codec                  | Stream                       |
 | ---------------------- | ---------------------------- |
-| `GzipCompressor`      | `GzipCompressorStream`      |
-| `GzipDecompressor`    | `GzipDecompressorStream`    |
-| `ZlibCompressor`      | `ZlibCompressorStream`      |
-| `ZlibDecompressor`    | `ZlibDecompressorStream`    |
-| `DeflateCompressor`   | `DeflateCompressorStream`   |
-| `DeflateDecompressor` | `DeflateDecompressorStream` |
+| `GzipCompressor`       | `GzipCompressorStream`       |
+| `GzipDecompressor`     | `GzipDecompressorStream`     |
+| `ZlibCompressor`       | `ZlibCompressorStream`       |
+| `ZlibDecompressor`     | `ZlibDecompressorStream`     |
+| `DeflateCompressor`    | `DeflateCompressorStream`    |
+| `DeflateDecompressor`  | `DeflateDecompressorStream`  |
 
 See docstrings and [TranscodingStreams.jl](https://github.com/bicycle1885/TranscodingStreams.jl) for details.
 

--- a/src/CodecZlib.jl
+++ b/src/CodecZlib.jl
@@ -4,22 +4,22 @@ module CodecZlib
 
 export
     # gzip
-    GzipCompression,
-    GzipCompressionStream,
-    GzipDecompression,
-    GzipDecompressionStream,
+    GzipCompressor,
+    GzipCompressorStream,
+    GzipDecompressor,
+    GzipDecompressorStream,
 
     # zlib
-    ZlibCompression,
-    ZlibCompressionStream,
-    ZlibDecompression,
-    ZlibDecompressionStream,
+    ZlibCompressor,
+    ZlibCompressorStream,
+    ZlibDecompressor,
+    ZlibDecompressorStream,
 
     # deflate
-    DeflateCompression,
-    DeflateCompressionStream,
-    DeflateDecompression,
-    DeflateDecompressionStream
+    DeflateCompressor,
+    DeflateCompressorStream,
+    DeflateDecompressor,
+    DeflateDecompressorStream
 
 import TranscodingStreams:
     TranscodingStreams,

--- a/src/CodecZlib.jl
+++ b/src/CodecZlib.jl
@@ -43,4 +43,20 @@ include("libz.jl")
 include("compression.jl")
 include("decompression.jl")
 
+# Deprecations
+# ------------
+
+@deprecate GzipCompression            GzipCompressor
+@deprecate GzipCompressionStream      GzipCompressorStream
+@deprecate GzipDecompression          GzipDecompressor
+@deprecate GzipDecompressionStream    GzipDecompressorStream
+@deprecate ZlibCompression            ZlibCompressor
+@deprecate ZlibCompressionStream      ZlibCompressorStream
+@deprecate ZlibDecompression          ZlibDecompressor
+@deprecate ZlibDecompressionStream    ZlibDecompressorStream
+@deprecate DeflateCompression         DeflateCompressor
+@deprecate DeflateCompressionStream   DeflateCompressorStream
+@deprecate DeflateDecompression       DeflateDecompressor
+@deprecate DeflateDecompressionStream DeflateDecompressorStream
+
 end # module

--- a/src/compression.jl
+++ b/src/compression.jl
@@ -1,9 +1,9 @@
-# Compression Codecs
+# Compressor Codecs
 # ==================
 
-abstract type CompressionCodec <: TranscodingStreams.Codec end
+abstract type CompressorCodec <: TranscodingStreams.Codec end
 
-function Base.show(io::IO, codec::CompressionCodec)
+function Base.show(io::IO, codec::CompressorCodec)
     print(io, summary(codec), "(level=$(codec.level), windowbits=$(codec.windowbits))")
 end
 
@@ -11,14 +11,14 @@ end
 # Gzip
 # ----
 
-struct GzipCompression <: CompressionCodec
+struct GzipCompressor <: CompressorCodec
     zstream::ZStream
     level::Int
     windowbits::Int
 end
 
 """
-    GzipCompression(;level=$(Z_DEFAULT_COMPRESSION), windowbits=$(Z_DEFAULT_WINDOWBITS))
+    GzipCompressor(;level=$(Z_DEFAULT_COMPRESSION), windowbits=$(Z_DEFAULT_WINDOWBITS))
 
 Create a gzip compression codec.
 
@@ -27,40 +27,40 @@ Arguments
 - `level`: compression level (-1..9)
 - `windowbits`: size of history buffer (8..15)
 """
-function GzipCompression(;level::Integer=Z_DEFAULT_COMPRESSION,
+function GzipCompressor(;level::Integer=Z_DEFAULT_COMPRESSION,
                          windowbits::Integer=Z_DEFAULT_WINDOWBITS)
     if !(-1 ≤ level ≤ 9)
         throw(ArgumentError("compression level must be within -1..9"))
     elseif !(8 ≤ windowbits ≤ 15)
         throw(ArgumentError("windowbits must be within 8..15"))
     end
-    return GzipCompression(ZStream(), level, windowbits+16)
+    return GzipCompressor(ZStream(), level, windowbits+16)
 end
 
-const GzipCompressionStream{S} = TranscodingStream{GzipCompression,S} where S<:IO
+const GzipCompressorStream{S} = TranscodingStream{GzipCompressor,S} where S<:IO
 
 """
-    GzipCompressionStream(stream::IO; kwargs...)
+    GzipCompressorStream(stream::IO; kwargs...)
 
-Create a gzip compression stream (see `GzipCompression` for `kwargs`).
+Create a gzip compression stream (see `GzipCompressor` for `kwargs`).
 """
-function GzipCompressionStream(stream::IO; kwargs...)
+function GzipCompressorStream(stream::IO; kwargs...)
     x, y = splitkwargs(kwargs, (:level, :windowbits))
-    return TranscodingStream(GzipCompression(;x...), stream; y...)
+    return TranscodingStream(GzipCompressor(;x...), stream; y...)
 end
 
 
 # Zlib
 # ----
 
-struct ZlibCompression <: CompressionCodec
+struct ZlibCompressor <: CompressorCodec
     zstream::ZStream
     level::Int
     windowbits::Int
 end
 
 """
-    ZlibCompression(;level=$(Z_DEFAULT_COMPRESSION), windowbits=$(Z_DEFAULT_WINDOWBITS))
+    ZlibCompressor(;level=$(Z_DEFAULT_COMPRESSION), windowbits=$(Z_DEFAULT_WINDOWBITS))
 
 Create a zlib compression codec.
 
@@ -69,40 +69,40 @@ Arguments
 - `level`: compression level (-1..9)
 - `windowbits`: size of history buffer (8..15)
 """
-function ZlibCompression(;level::Integer=Z_DEFAULT_COMPRESSION,
+function ZlibCompressor(;level::Integer=Z_DEFAULT_COMPRESSION,
                          windowbits::Integer=Z_DEFAULT_WINDOWBITS)
     if !(-1 ≤ level ≤ 9)
         throw(ArgumentError("compression level must be within -1..9"))
     elseif !(8 ≤ windowbits ≤ 15)
         throw(ArgumentError("windowbits must be within 8..15"))
     end
-    return ZlibCompression(ZStream(), level, windowbits)
+    return ZlibCompressor(ZStream(), level, windowbits)
 end
 
-const ZlibCompressionStream{S} = TranscodingStream{ZlibCompression,S} where S<:IO
+const ZlibCompressorStream{S} = TranscodingStream{ZlibCompressor,S} where S<:IO
 
 """
-    ZlibCompressionStream(stream::IO)
+    ZlibCompressorStream(stream::IO)
 
-Create a zlib compression stream (see `ZlibCompression` for `kwargs`).
+Create a zlib compression stream (see `ZlibCompressor` for `kwargs`).
 """
-function ZlibCompressionStream(stream::IO; kwargs...)
+function ZlibCompressorStream(stream::IO; kwargs...)
     x, y = splitkwargs(kwargs, (:level, :windowbits))
-    return TranscodingStream(ZlibCompression(;x...), stream; y...)
+    return TranscodingStream(ZlibCompressor(;x...), stream; y...)
 end
 
 
 # Deflate
 # -------
 
-struct DeflateCompression <: CompressionCodec
+struct DeflateCompressor <: CompressorCodec
     zstream::ZStream
     level::Int
     windowbits::Int
 end
 
 """
-    DeflateCompression(;level=$(Z_DEFAULT_COMPRESSION), windowbits=$(Z_DEFAULT_COMPRESSION))
+    DeflateCompressor(;level=$(Z_DEFAULT_COMPRESSION), windowbits=$(Z_DEFAULT_COMPRESSION))
 
 Create a deflate compression codec.
 
@@ -111,33 +111,33 @@ Arguments
 - `level`: compression level (-1..9)
 - `windowbits`: size of history buffer (8..15)
 """
-function DeflateCompression(;level::Integer=Z_DEFAULT_COMPRESSION,
+function DeflateCompressor(;level::Integer=Z_DEFAULT_COMPRESSION,
                         windowbits::Integer=Z_DEFAULT_WINDOWBITS)
     if !(-1 ≤ level ≤ 9)
         throw(ArgumentError("compression level must be within -1..9"))
     elseif !(8 ≤ windowbits ≤ 15)
         throw(ArgumentError("windowbits must be within 8..15"))
     end
-    return DeflateCompression(ZStream(), level, -Int(windowbits))
+    return DeflateCompressor(ZStream(), level, -Int(windowbits))
 end
 
-const DeflateCompressionStream{S} = TranscodingStream{DeflateCompression,S} where S<:IO
+const DeflateCompressorStream{S} = TranscodingStream{DeflateCompressor,S} where S<:IO
 
 """
-    DeflateCompressionStream(stream::IO; kwargs...)
+    DeflateCompressorStream(stream::IO; kwargs...)
 
-Create a deflate compression stream (see `DeflateCompression` for `kwargs`).
+Create a deflate compression stream (see `DeflateCompressor` for `kwargs`).
 """
-function DeflateCompressionStream(stream::IO; kwargs...)
+function DeflateCompressorStream(stream::IO; kwargs...)
     x, y = splitkwargs(kwargs, (:level, :windowbits))
-    return TranscodingStream(DeflateCompression(;x...), stream; y...)
+    return TranscodingStream(DeflateCompressor(;x...), stream; y...)
 end
 
 
 # Methods
 # -------
 
-function TranscodingStreams.initialize(codec::CompressionCodec)
+function TranscodingStreams.initialize(codec::CompressorCodec)
     code = deflate_init!(codec.zstream, codec.level, codec.windowbits)
     if code != Z_OK
         zerror(codec.zstream, code)
@@ -145,7 +145,7 @@ function TranscodingStreams.initialize(codec::CompressionCodec)
     return
 end
 
-function TranscodingStreams.finalize(codec::CompressionCodec)
+function TranscodingStreams.finalize(codec::CompressorCodec)
     zstream = codec.zstream
     if zstream.state != C_NULL
         code = deflate_end!(zstream)
@@ -156,7 +156,7 @@ function TranscodingStreams.finalize(codec::CompressionCodec)
     return
 end
 
-function TranscodingStreams.startproc(codec::CompressionCodec, state::Symbol, error::Error)
+function TranscodingStreams.startproc(codec::CompressorCodec, state::Symbol, error::Error)
     code = deflate_reset!(codec.zstream)
     if code == Z_OK
         return :ok
@@ -166,7 +166,7 @@ function TranscodingStreams.startproc(codec::CompressionCodec, state::Symbol, er
     end
 end
 
-function TranscodingStreams.process(codec::CompressionCodec, input::Memory, output::Memory, error::Error)
+function TranscodingStreams.process(codec::CompressorCodec, input::Memory, output::Memory, error::Error)
     zstream = codec.zstream
     zstream.next_in = input.ptr
     zstream.avail_in = input.size

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -1,9 +1,9 @@
-# Decompression Codecs
+# Decompressor Codecs
 # ====================
 
-abstract type DecompressionCodec <: TranscodingStreams.Codec end
+abstract type DecompressorCodec <: TranscodingStreams.Codec end
 
-function Base.show(io::IO, codec::DecompressionCodec)
+function Base.show(io::IO, codec::DecompressorCodec)
     print(io, summary(codec), "(windowbits=$(codec.windowbits))")
 end
 
@@ -11,13 +11,13 @@ end
 # Gzip
 # ----
 
-struct GzipDecompression <: DecompressionCodec
+struct GzipDecompressor <: DecompressorCodec
     zstream::ZStream
     windowbits::Int
 end
 
 """
-    GzipDecompression(;windowbits=$(Z_DEFAULT_WINDOWBITS), gziponly=false)
+    GzipDecompressor(;windowbits=$(Z_DEFAULT_WINDOWBITS), gziponly=false)
 
 Create a gzip decompressor codec.
 
@@ -28,36 +28,36 @@ Arguments
 - `windowbits`: size of history buffer (8..15)
 - `gziponly`: flag to inactivate data format detection
 """
-function GzipDecompression(;windowbits::Integer=Z_DEFAULT_WINDOWBITS, gziponly::Bool=false)
+function GzipDecompressor(;windowbits::Integer=Z_DEFAULT_WINDOWBITS, gziponly::Bool=false)
     if !(8 ≤ windowbits ≤ 15)
         throw(ArgumentError("windowbits must be within 8..15"))
     end
-    return GzipDecompression(ZStream(), windowbits+(gziponly?16:32))
+    return GzipDecompressor(ZStream(), windowbits+(gziponly?16:32))
 end
 
-const GzipDecompressionStream{S} = TranscodingStream{GzipDecompression,S} where S<:IO
+const GzipDecompressorStream{S} = TranscodingStream{GzipDecompressor,S} where S<:IO
 
 """
-    GzipDecompressionStream(stream::IO; kwargs...)
+    GzipDecompressorStream(stream::IO; kwargs...)
 
-Create a gzip decompression stream (see `GzipDecompression` for `kwargs`).
+Create a gzip decompression stream (see `GzipDecompressor` for `kwargs`).
 """
-function GzipDecompressionStream(stream::IO; kwargs...)
+function GzipDecompressorStream(stream::IO; kwargs...)
     x, y = splitkwargs(kwargs, (:windowbits, :gziponly))
-    return TranscodingStream(GzipDecompression(;x...), stream; y...)
+    return TranscodingStream(GzipDecompressor(;x...), stream; y...)
 end
 
 
 # Zlib
 # ----
 
-struct ZlibDecompression <: DecompressionCodec
+struct ZlibDecompressor <: DecompressorCodec
     zstream::ZStream
     windowbits::Int
 end
 
 """
-    ZlibDecompression(;windowbits=$(Z_DEFAULT_WINDOWBITS))
+    ZlibDecompressor(;windowbits=$(Z_DEFAULT_WINDOWBITS))
 
 Create a zlib decompression codec.
 
@@ -65,36 +65,36 @@ Arguments
 ---------
 - `windowbits`: size of history buffer (8..15)
 """
-function ZlibDecompression(;windowbits::Integer=Z_DEFAULT_WINDOWBITS)
+function ZlibDecompressor(;windowbits::Integer=Z_DEFAULT_WINDOWBITS)
     if !(8 ≤ windowbits ≤ 15)
         throw(ArgumentError("windowbits must be within 8..15"))
     end
-    return ZlibDecompression(ZStream(), windowbits)
+    return ZlibDecompressor(ZStream(), windowbits)
 end
 
-const ZlibDecompressionStream{S} = TranscodingStream{ZlibDecompression,S} where S<:IO
+const ZlibDecompressorStream{S} = TranscodingStream{ZlibDecompressor,S} where S<:IO
 
 """
-    ZlibDecompressionStream(stream::IO; kwargs...)
+    ZlibDecompressorStream(stream::IO; kwargs...)
 
-Create a deflate decompression stream (see `ZlibDecompression` for `kwargs`).
+Create a deflate decompression stream (see `ZlibDecompressor` for `kwargs`).
 """
-function ZlibDecompressionStream(stream::IO; kwargs...)
+function ZlibDecompressorStream(stream::IO; kwargs...)
     x, y = splitkwargs(kwargs, (:windowbits,))
-    return TranscodingStream(ZlibDecompression(;x...), stream; y...)
+    return TranscodingStream(ZlibDecompressor(;x...), stream; y...)
 end
 
 
 # Deflate
 # -------
 
-struct DeflateDecompression <: DecompressionCodec
+struct DeflateDecompressor <: DecompressorCodec
     zstream::ZStream
     windowbits::Int
 end
 
 """
-    DeflateDecompression(;windowbits=$(Z_DEFAULT_WINDOWBITS))
+    DeflateDecompressor(;windowbits=$(Z_DEFAULT_WINDOWBITS))
 
 Create a deflate decompression codec.
 
@@ -102,30 +102,30 @@ Arguments
 ---------
 - `windowbits`: size of history buffer (8..15)
 """
-function DeflateDecompression(;windowbits::Integer=Z_DEFAULT_WINDOWBITS)
+function DeflateDecompressor(;windowbits::Integer=Z_DEFAULT_WINDOWBITS)
     if !(8 ≤ windowbits ≤ 15)
         throw(ArgumentError("windowbits must be within 8..15"))
     end
-    return DeflateDecompression(ZStream(), -Int(windowbits))
+    return DeflateDecompressor(ZStream(), -Int(windowbits))
 end
 
-const DeflateDecompressionStream{S} = TranscodingStream{DeflateDecompression,S} where S<:IO
+const DeflateDecompressorStream{S} = TranscodingStream{DeflateDecompressor,S} where S<:IO
 
 """
-    DeflateDecompressionStream(stream::IO; kwargs...)
+    DeflateDecompressorStream(stream::IO; kwargs...)
 
-Create a deflate decompression stream (see `DeflateDecompression` for `kwargs`).
+Create a deflate decompression stream (see `DeflateDecompressor` for `kwargs`).
 """
-function DeflateDecompressionStream(stream::IO; kwargs...)
+function DeflateDecompressorStream(stream::IO; kwargs...)
     x, y = splitkwargs(kwargs, (:windowbits,))
-    return TranscodingStream(DeflateDecompression(;x...), stream; y...)
+    return TranscodingStream(DeflateDecompressor(;x...), stream; y...)
 end
 
 
 # Methods
 # -------
 
-function TranscodingStreams.initialize(codec::DecompressionCodec)
+function TranscodingStreams.initialize(codec::DecompressorCodec)
     code = inflate_init!(codec.zstream, codec.windowbits)
     if code != Z_OK
         zerror(codec.zstream, code)
@@ -133,7 +133,7 @@ function TranscodingStreams.initialize(codec::DecompressionCodec)
     return
 end
 
-function TranscodingStreams.finalize(codec::DecompressionCodec)
+function TranscodingStreams.finalize(codec::DecompressorCodec)
     zstream = codec.zstream
     if zstream.state != C_NULL
         code = inflate_end!(zstream)
@@ -144,7 +144,7 @@ function TranscodingStreams.finalize(codec::DecompressionCodec)
     return
 end
 
-function TranscodingStreams.startproc(codec::DecompressionCodec, ::Symbol, error::Error)
+function TranscodingStreams.startproc(codec::DecompressorCodec, ::Symbol, error::Error)
     code = inflate_reset!(codec.zstream)
     if code == Z_OK
         return :ok
@@ -154,7 +154,7 @@ function TranscodingStreams.startproc(codec::DecompressionCodec, ::Symbol, error
     end
 end
 
-function TranscodingStreams.process(codec::DecompressionCodec, input::Memory, output::Memory, error::Error)
+function TranscodingStreams.process(codec::DecompressorCodec, input::Memory, output::Memory, error::Error)
     zstream = codec.zstream
     zstream.next_in = input.ptr
     zstream.avail_in = input.size

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,9 @@
 using CodecZlib
-using Base.Test
+if VERSION < v"0.7-"
+    using Base.Test
+else
+    using Test
+end
 import TranscodingStreams:
     TranscodingStream,
     test_roundtrip_read,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,15 +10,15 @@ import TranscodingStreams:
 const testdir = @__DIR__
 
 @testset "Gzip Codec" begin
-    codec = GzipCompression()
-    @test codec isa GzipCompression
-    @test ismatch(r"^CodecZlib.GzipCompression\(level=-1, windowbits=\d+\)$", sprint(show, codec))
+    codec = GzipCompressor()
+    @test codec isa GzipCompressor
+    @test ismatch(r"^CodecZlib.GzipCompressor\(level=-1, windowbits=\d+\)$", sprint(show, codec))
     @test CodecZlib.initialize(codec) === nothing
     @test CodecZlib.finalize(codec) === nothing
 
-    codec = GzipDecompression()
-    @test codec isa GzipDecompression
-    @test ismatch(r"^CodecZlib.GzipDecompression\(windowbits=\d+\)$", sprint(show, codec))
+    codec = GzipDecompressor()
+    @test codec isa GzipDecompressor
+    @test ismatch(r"^CodecZlib.GzipDecompressor\(windowbits=\d+\)$", sprint(show, codec))
     @test CodecZlib.initialize(codec) === nothing
     @test CodecZlib.finalize(codec) === nothing
 
@@ -26,7 +26,7 @@ const testdir = @__DIR__
     gzip_data = b"\x1f\x8b\x08\x00R\xcc\x10Y\x02\xffK\xcb\xcf\x07\x00!es\x8c\x03\x00\x00\x00"
 
     file = IOBuffer(gzip_data)
-    stream = GzipDecompressionStream(file)
+    stream = GzipDecompressorStream(file)
     @test !eof(stream)
     @test read(stream) == b"foo"
     @test eof(stream)
@@ -35,7 +35,7 @@ const testdir = @__DIR__
     @test !isopen(file)
 
     file = IOBuffer(gzip_data)
-    stream = GzipDecompressionStream(file, bufsize=1)
+    stream = GzipDecompressorStream(file, bufsize=1)
     @test length(stream.state.buffer1) == 1
     @test length(stream.state.buffer2) == 1
     @test read(stream) == b"foo"
@@ -45,7 +45,7 @@ const testdir = @__DIR__
     gzip_data_corrupted = copy(gzip_data)
     gzip_data_corrupted[1] = 0x00  # corrupt header
     file = IOBuffer(gzip_data_corrupted)
-    stream = GzipDecompressionStream(file)
+    stream = GzipDecompressorStream(file)
     @test_throws ErrorException read(stream)
     @test_throws ArgumentError read(stream)
     @test !isopen(stream)
@@ -54,25 +54,25 @@ const testdir = @__DIR__
     @test !isopen(stream)
     @test !isopen(file)
 
-    stream = TranscodingStream(GzipDecompression(gziponly=false), IOBuffer(gzip_data))
+    stream = TranscodingStream(GzipDecompressor(gziponly=false), IOBuffer(gzip_data))
     @test read(stream) == b"foo"
     close(stream)
 
-    stream = TranscodingStream(GzipDecompression(gziponly=true), IOBuffer(gzip_data))
+    stream = TranscodingStream(GzipDecompressor(gziponly=true), IOBuffer(gzip_data))
     @test read(stream) == b"foo"
     close(stream)
 
     file = IOBuffer(vcat(gzip_data, gzip_data))
-    stream = GzipDecompressionStream(file)
+    stream = GzipDecompressorStream(file)
     @test read(stream) == b"foofoo"
     close(stream)
 
     open(joinpath(testdir, "foo.txt.gz")) do file
-        @test read(GzipDecompressionStream(file)) == b"foo"
+        @test read(GzipDecompressorStream(file)) == b"foo"
     end
 
     file = IOBuffer("foo")
-    stream = GzipCompressionStream(file)
+    stream = GzipCompressorStream(file)
     @test !eof(stream)
     @test length(read(stream)) > 0
     @test eof(stream)
@@ -81,7 +81,7 @@ const testdir = @__DIR__
     @test !isopen(file)
 
     mktemp() do path, file
-        stream = GzipDecompressionStream(file)
+        stream = GzipDecompressorStream(file)
         @test write(stream, gzip_data) == length(gzip_data)
         @test close(stream) === nothing
         @test !isopen(stream)
@@ -90,7 +90,7 @@ const testdir = @__DIR__
     end
 
     mktemp() do path, file
-        stream = GzipCompressionStream(file)
+        stream = GzipCompressorStream(file)
         @test write(stream, "foo") == 3
         @test close(stream) === nothing
         @test !isopen(stream)
@@ -98,29 +98,29 @@ const testdir = @__DIR__
         @test length(read(path)) > 0
     end
 
-    @test GzipCompressionStream <: TranscodingStream
-    @test GzipDecompressionStream <: TranscodingStream
+    @test GzipCompressorStream <: TranscodingStream
+    @test GzipDecompressorStream <: TranscodingStream
 
-    test_roundtrip_read(GzipCompressionStream, GzipDecompressionStream)
-    test_roundtrip_write(GzipCompressionStream, GzipDecompressionStream)
-    test_roundtrip_lines(GzipCompressionStream, GzipDecompressionStream)
-    test_roundtrip_transcode(GzipCompression, GzipDecompression)
+    test_roundtrip_read(GzipCompressorStream, GzipDecompressorStream)
+    test_roundtrip_write(GzipCompressorStream, GzipDecompressorStream)
+    test_roundtrip_lines(GzipCompressorStream, GzipDecompressorStream)
+    test_roundtrip_transcode(GzipCompressor, GzipDecompressor)
 
-    @test_throws ArgumentError GzipCompression(level=10)
-    @test_throws ArgumentError GzipCompression(windowbits=16)
-    @test_throws ArgumentError GzipDecompression(windowbits=16)
+    @test_throws ArgumentError GzipCompressor(level=10)
+    @test_throws ArgumentError GzipCompressor(windowbits=16)
+    @test_throws ArgumentError GzipDecompressor(windowbits=16)
 end
 
 @testset "Zlib Codec" begin
-    codec = ZlibCompression()
-    @test codec isa ZlibCompression
-    @test ismatch(r"^CodecZlib\.ZlibCompression\(level=-1, windowbits=\d+\)$", sprint(show, codec))
+    codec = ZlibCompressor()
+    @test codec isa ZlibCompressor
+    @test ismatch(r"^CodecZlib\.ZlibCompressor\(level=-1, windowbits=\d+\)$", sprint(show, codec))
     @test CodecZlib.initialize(codec) === nothing
     @test CodecZlib.finalize(codec) === nothing
 
-    codec = ZlibDecompression()
-    @test codec isa ZlibDecompression
-    @test ismatch(r"^CodecZlib\.ZlibDecompression\(windowbits=\d+\)$", sprint(show, codec))
+    codec = ZlibDecompressor()
+    @test codec isa ZlibDecompressor
+    @test ismatch(r"^CodecZlib\.ZlibDecompressor\(windowbits=\d+\)$", sprint(show, codec))
     @test CodecZlib.initialize(codec) === nothing
     @test CodecZlib.finalize(codec) === nothing
 
@@ -128,7 +128,7 @@ end
     zlib_data = b"x\x9cK\xcb\xcf\x07\x00\x02\x82\x01E"
 
     file = IOBuffer(zlib_data)
-    stream = ZlibDecompressionStream(file)
+    stream = ZlibDecompressorStream(file)
     @test !eof(stream)
     @test read(stream) == b"foo"
     @test eof(stream)
@@ -137,22 +137,22 @@ end
     @test !isopen(file)
 
     file = IOBuffer(zlib_data)
-    stream = ZlibDecompressionStream(file, bufsize=1)
+    stream = ZlibDecompressorStream(file, bufsize=1)
     @test length(stream.state.buffer1) == 1
     @test length(stream.state.buffer2) == 1
     @test read(stream) == b"foo"
     close(stream)
 
-    stream = TranscodingStream(GzipDecompression(gziponly=false), IOBuffer(zlib_data))
+    stream = TranscodingStream(GzipDecompressor(gziponly=false), IOBuffer(zlib_data))
     @test read(stream) == b"foo"
     close(stream)
 
-    stream = TranscodingStream(GzipDecompression(gziponly=true), IOBuffer(zlib_data))
+    stream = TranscodingStream(GzipDecompressor(gziponly=true), IOBuffer(zlib_data))
     @test_throws Exception read(stream)
     close(stream)
 
     file = IOBuffer(b"foo")
-    stream = ZlibCompressionStream(file)
+    stream = ZlibCompressorStream(file)
     @test !eof(stream)
     @test read(stream) == zlib_data
     @test eof(stream)
@@ -161,7 +161,7 @@ end
     @test !isopen(file)
 
     mktemp() do path, file
-        stream = ZlibDecompressionStream(file)
+        stream = ZlibDecompressorStream(file)
         @test write(stream, zlib_data) == length(zlib_data)
         @test close(stream) === nothing
         @test !isopen(stream)
@@ -170,7 +170,7 @@ end
     end
 
     mktemp() do path, file
-        stream = ZlibCompressionStream(file)
+        stream = ZlibCompressorStream(file)
         @test write(stream, "foo") == 3
         @test close(stream) === nothing
         @test !isopen(stream)
@@ -178,42 +178,42 @@ end
         @test read(path) == zlib_data
     end
 
-    @test ZlibCompressionStream <: TranscodingStream
-    @test ZlibDecompressionStream <: TranscodingStream
+    @test ZlibCompressorStream <: TranscodingStream
+    @test ZlibDecompressorStream <: TranscodingStream
 
-    test_roundtrip_read(ZlibCompressionStream, ZlibDecompressionStream)
-    test_roundtrip_write(ZlibCompressionStream, ZlibDecompressionStream)
-    test_roundtrip_lines(ZlibCompressionStream, ZlibDecompressionStream)
-    test_roundtrip_transcode(ZlibCompression, ZlibDecompression)
+    test_roundtrip_read(ZlibCompressorStream, ZlibDecompressorStream)
+    test_roundtrip_write(ZlibCompressorStream, ZlibDecompressorStream)
+    test_roundtrip_lines(ZlibCompressorStream, ZlibDecompressorStream)
+    test_roundtrip_transcode(ZlibCompressor, ZlibDecompressor)
 
-    @test_throws ArgumentError ZlibCompression(level=10)
-    @test_throws ArgumentError ZlibCompression(windowbits=16)
-    @test_throws ArgumentError ZlibDecompression(windowbits=16)
+    @test_throws ArgumentError ZlibCompressor(level=10)
+    @test_throws ArgumentError ZlibCompressor(windowbits=16)
+    @test_throws ArgumentError ZlibDecompressor(windowbits=16)
 end
 
 @testset "Deflate Codec" begin
-    codec = DeflateCompression()
-    @test codec isa DeflateCompression
-    @test ismatch(r"^CodecZlib\.DeflateCompression\(level=-1, windowbits=-\d+\)$", sprint(show, codec))
+    codec = DeflateCompressor()
+    @test codec isa DeflateCompressor
+    @test ismatch(r"^CodecZlib\.DeflateCompressor\(level=-1, windowbits=-\d+\)$", sprint(show, codec))
     @test CodecZlib.initialize(codec) === nothing
     # FIXME: This test fails.
     #@test CodecZlib.finalize(codec) === nothing
 
-    codec = DeflateDecompression()
-    @test codec isa DeflateDecompression
-    @test ismatch(r"^CodecZlib\.DeflateDecompression\(windowbits=-\d+\)$", sprint(show, codec))
+    codec = DeflateDecompressor()
+    @test codec isa DeflateDecompressor
+    @test ismatch(r"^CodecZlib\.DeflateDecompressor\(windowbits=-\d+\)$", sprint(show, codec))
     @test CodecZlib.initialize(codec) === nothing
     @test CodecZlib.finalize(codec) === nothing
 
-    test_roundtrip_read(DeflateCompressionStream, DeflateDecompressionStream)
-    test_roundtrip_write(DeflateCompressionStream, DeflateDecompressionStream)
-    test_roundtrip_lines(DeflateCompressionStream, DeflateDecompressionStream)
-    test_roundtrip_transcode(DeflateCompression, DeflateDecompression)
+    test_roundtrip_read(DeflateCompressorStream, DeflateDecompressorStream)
+    test_roundtrip_write(DeflateCompressorStream, DeflateDecompressorStream)
+    test_roundtrip_lines(DeflateCompressorStream, DeflateDecompressorStream)
+    test_roundtrip_transcode(DeflateCompressor, DeflateDecompressor)
 
-    @test DeflateCompressionStream <: TranscodingStream
-    @test DeflateDecompressionStream <: TranscodingStream
+    @test DeflateCompressorStream <: TranscodingStream
+    @test DeflateDecompressorStream <: TranscodingStream
 
-    @test_throws ArgumentError DeflateCompression(level=10)
-    @test_throws ArgumentError DeflateCompression(windowbits=16)
-    @test_throws ArgumentError DeflateDecompression(windowbits=16)
+    @test_throws ArgumentError DeflateCompressor(level=10)
+    @test_throws ArgumentError DeflateCompressor(windowbits=16)
+    @test_throws ArgumentError DeflateDecompressor(windowbits=16)
 end


### PR DESCRIPTION
Because I chose the name `Base64(En|De)coder` in https://github.com/bicycle1885/CodecBase.jl, it is more consistent to rename things in this package. Old names are deprecated.