### PR TITLE
Provide a simple source build fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+deps/deps.jl
+deps/src
+deps/lib


### PR DESCRIPTION
As of this writing, BinaryBuilder does not support all of the platforms supported by Julia, which means that CodecZlib is not usable on those systems. This provides a simple fallback for building from source, using the same version of zlib used by ZlibBuilder.

With these changes, CodecZlib builds and passes all tests on FreeBSD 11.1, Julia 0.7.0-DEV.4706.