### PR TITLE
Calling `seekend` on a stream while reading is currently not valid.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -232,8 +232,6 @@ end
         @test read(stream, 3) == b"abr"
         seekstart(stream)
         @test read(stream, 3) == b"abr"
-        seekend(stream)
-        #@test eof(stream)
     end
 
     @testset "panic" begin


### PR DESCRIPTION
See https://github.com/JuliaIO/TranscodingStreams.jl/issues/109

I think `seekend` in a future version of `TranscodingStreams` will behave differently to fix this issue, so it shouldn't be tested here yet.