### PR TITLE
`test_roundtrip_seekstart`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,6 +106,9 @@ const testdir = @__DIR__
     test_roundtrip_read(GzipCompressorStream, GzipDecompressorStream)
     test_roundtrip_write(GzipCompressorStream, GzipDecompressorStream)
     test_roundtrip_lines(GzipCompressorStream, GzipDecompressorStream)
+    if isdefined(TranscodingStreams, :test_roundtrip_seekstart)
+        TranscodingStreams.test_roundtrip_seekstart(GzipCompressorStream, GzipDecompressorStream)
+    end
     test_roundtrip_transcode(GzipCompressor, GzipDecompressor)
 
     @test_throws ArgumentError GzipCompressor(level=10)
@@ -186,6 +189,9 @@ end
     test_roundtrip_read(ZlibCompressorStream, ZlibDecompressorStream)
     test_roundtrip_write(ZlibCompressorStream, ZlibDecompressorStream)
     test_roundtrip_lines(ZlibCompressorStream, ZlibDecompressorStream)
+    if isdefined(TranscodingStreams, :test_roundtrip_seekstart)
+        TranscodingStreams.test_roundtrip_seekstart(ZlibCompressorStream, ZlibDecompressorStream)
+    end
     test_roundtrip_transcode(ZlibCompressor, ZlibDecompressor)
 
     @test_throws ArgumentError ZlibCompressor(level=10)
@@ -210,6 +216,9 @@ end
     test_roundtrip_read(DeflateCompressorStream, DeflateDecompressorStream)
     test_roundtrip_write(DeflateCompressorStream, DeflateDecompressorStream)
     test_roundtrip_lines(DeflateCompressorStream, DeflateDecompressorStream)
+    if isdefined(TranscodingStreams, :test_roundtrip_seekstart)
+        TranscodingStreams.test_roundtrip_seekstart(DeflateCompressorStream, DeflateDecompressorStream)
+    end
     test_roundtrip_transcode(DeflateCompressor, DeflateDecompressor)
 
     @test DeflateCompressorStream <: TranscodingStream


### PR DESCRIPTION
[`test_roundtrip_seekstart`](https://github.com/JuliaIO/TranscodingStreams.jl/blob/d92fd8b9fb0b9314d82b40a96774f7f745b4dab1/ext/TestExt.jl#L65-L81) adds additional test coverage for resetting the compression session.

Ref: https://github.com/JuliaIO/TranscodingStreams.jl/issues/217