### PR TITLE
Bump compat for TranscodingStreams to 0.11, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,14 +2,14 @@ name = "CodecZlib"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
 license = "MIT"
 authors = ["Kenta Sato <bicycle1885@gmail.com>"]
-version = "0.7.4"
+version = "0.7.5"
 
 [deps]
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 Zlib_jll = "83775a58-1f1d-513f-b197-d71354ab007a"
 
 [compat]
-TranscodingStreams = "0.9, 0.10"
+TranscodingStreams = "0.9, 0.10, 0.11"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
This update shouldn't affect the public API of this package. TranscodingStreams release notes: https://github.com/JuliaIO/TranscodingStreams.jl/releases/tag/v0.11.0