### PR TITLE
Update CI, julia compat, and readme links

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - 'lts'
           - '1'
           - 'nightly'
         os:
@@ -28,13 +28,22 @@ jobs:
           - windows-latest
           - macos-latest
         arch:
-          - x64
+          - default
+          - x86
+        exclude:
+          - os: macos-latest
+            arch: x86
+        include:
+          - os: ubuntu-latest
+            version: 'min'
+            arch: x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+          show-versioninfo: true
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -1,0 +1,45 @@
+name: Downstream
+on:
+  push:
+    branches: [master]
+    tags: [v*]
+  pull_request:
+
+jobs:
+  test:
+    name: ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - "CSV"
+          - "Documenter"
+          - "HTTP"
+          - "JLD2"
+          - "RData"
+          - "WriteVTK"
+          - "ZipArchives"
+          - "ZipStreams"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: 1
+          arch: x64
+          show-versioninfo: true
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: Load this and run the downstream tests
+        shell: julia --color=yes {0}
+        run: |
+          using Pkg
+          Pkg.Registry.update()
+          Pkg.activate(;temp=true)
+          # force it to use this PR's version of the package
+          ENV["JULIA_PKG_DEVDIR"]= mktempdir()
+          Pkg.develop([
+            PackageSpec(path="."),
+            PackageSpec(name="${{ matrix.package }}"),
+          ])
+          Pkg.update()
+          Pkg.test("${{ matrix.package }}")

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,14 @@
+#Mac OS X
+*.DS_Store
+
+#VS Code
+/.vscode/
+
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
 /Manifest.toml
+/test/Manifest.toml
 /.envrc
 /deps/deps.jl
 /deps/build.log

--- a/Project.toml
+++ b/Project.toml
@@ -10,4 +10,4 @@ Zlib_jll = "83775a58-1f1d-513f-b197-d71354ab007a"
 
 [compat]
 TranscodingStreams = "0.9, 0.10, 0.11"
-julia = "1.3"
+julia = "1.6"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 CodecZlib.jl
 ============
 
-[![codecov.io][codecov-img]][codecov-url]
+[![CI](https://github.com/JuliaIO/CodecZlib.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/JuliaIO/CodecZlib.jl/actions/workflows/CI.yml)
+[![codecov](https://codecov.io/gh/JuliaIO/CodecZlib.jl/graph/badge.svg?token=6V3Z847Ywr)](https://codecov.io/gh/JuliaIO/CodecZlib.jl)
 
 ## Installation
 
@@ -48,11 +49,4 @@ This package exports following codecs and streams:
 | `DeflateCompressor`    | `DeflateCompressorStream`    |
 | `DeflateDecompressor`  | `DeflateDecompressorStream`  |
 
-See docstrings and [TranscodingStreams.jl](https://github.com/bicycle1885/TranscodingStreams.jl) for details.
-
-[travisci-img]: https://travis-ci.org/JuliaIO/CodecZlib.jl.svg?branch=master
-[travisci-url]: https://travis-ci.org/JuliaIO/CodecZlib.jl
-[appveyor-img]: https://ci.appveyor.com/api/projects/status/xy5bx1fdvuxgemph?svg=true
-[appveyor-url]: https://ci.appveyor.com/project/bicycle1885/codeczlib-jl
-[codecov-img]: http://codecov.io/github/JuliaIO/CodecZlib.jl/coverage.svg?branch=master
-[codecov-url]: http://codecov.io/github/JuliaIO/CodecZlib.jl?branch=master
+See docstrings and [TranscodingStreams.jl](https://github.com/JuliaIO/TranscodingStreams.jl) for details.


### PR DESCRIPTION
The latest version of TranscodingStreams requires at least julia 1.6.