### PR TITLE
Add warning about `serialize` and `deepcopy` not being supported

### DIFF
--- a/src/compression.jl
+++ b/src/compression.jl
@@ -26,6 +26,9 @@ Arguments
 ---------
 - `level`: compression level (-1..9)
 - `windowbits`: size of history buffer (9..15)
+
+!!! warning
+    `serialize` and `deepcopy` will not work with this codec due to stored raw pointers.
 """
 function GzipCompressor(;level::Integer=Z_DEFAULT_COMPRESSION,
                          windowbits::Integer=Z_DEFAULT_WINDOWBITS)
@@ -43,6 +46,9 @@ const GzipCompressorStream{S} = TranscodingStream{GzipCompressor,S} where S<:IO
     GzipCompressorStream(stream::IO; kwargs...)
 
 Create a gzip compression stream (see `GzipCompressor` for `kwargs`).
+
+!!! warning
+    `serialize` and `deepcopy` will not work with this stream due to stored raw pointers.
 """
 function GzipCompressorStream(stream::IO; kwargs...)
     x, y = splitkwargs(kwargs, (:level, :windowbits))
@@ -68,6 +74,9 @@ Arguments
 ---------
 - `level`: compression level (-1..9)
 - `windowbits`: size of history buffer (9..15)
+
+!!! warning
+    `serialize` and `deepcopy` will not work with this codec due to stored raw pointers.
 """
 function ZlibCompressor(;level::Integer=Z_DEFAULT_COMPRESSION,
                          windowbits::Integer=Z_DEFAULT_WINDOWBITS)
@@ -85,6 +94,9 @@ const ZlibCompressorStream{S} = TranscodingStream{ZlibCompressor,S} where S<:IO
     ZlibCompressorStream(stream::IO)
 
 Create a zlib compression stream (see `ZlibCompressor` for `kwargs`).
+
+!!! warning
+    `serialize` and `deepcopy` will not work with this stream due to stored raw pointers.
 """
 function ZlibCompressorStream(stream::IO; kwargs...)
     x, y = splitkwargs(kwargs, (:level, :windowbits))
@@ -110,6 +122,9 @@ Arguments
 ---------
 - `level`: compression level (-1..9)
 - `windowbits`: size of history buffer (9..15)
+
+!!! warning
+    `serialize` and `deepcopy` will not work with this codec due to stored raw pointers.
 """
 function DeflateCompressor(;level::Integer=Z_DEFAULT_COMPRESSION,
                         windowbits::Integer=Z_DEFAULT_WINDOWBITS)
@@ -127,6 +142,9 @@ const DeflateCompressorStream{S} = TranscodingStream{DeflateCompressor,S} where 
     DeflateCompressorStream(stream::IO; kwargs...)
 
 Create a deflate compression stream (see `DeflateCompressor` for `kwargs`).
+
+!!! warning
+    `serialize` and `deepcopy` will not work with this stream due to stored raw pointers.
 """
 function DeflateCompressorStream(stream::IO; kwargs...)
     x, y = splitkwargs(kwargs, (:level, :windowbits))

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -27,6 +27,9 @@ Arguments
 ---------
 - `windowbits`: size of history buffer (8..15)
 - `gziponly`: flag to inactivate data format detection
+
+!!! warning
+    `serialize` and `deepcopy` will not work with this codec due to stored raw pointers.
 """
 function GzipDecompressor(;windowbits::Integer=Z_DEFAULT_WINDOWBITS, gziponly::Bool=false)
     if !(8 ≤ windowbits ≤ 15)
@@ -41,6 +44,9 @@ const GzipDecompressorStream{S} = TranscodingStream{GzipDecompressor,S} where S<
     GzipDecompressorStream(stream::IO; kwargs...)
 
 Create a gzip decompression stream (see `GzipDecompressor` for `kwargs`).
+
+!!! warning
+    `serialize` and `deepcopy` will not work with this stream due to stored raw pointers.
 """
 function GzipDecompressorStream(stream::IO; kwargs...)
     x, y = splitkwargs(kwargs, (:windowbits, :gziponly))
@@ -64,6 +70,9 @@ Create a zlib decompression codec.
 Arguments
 ---------
 - `windowbits`: size of history buffer (8..15)
+
+!!! warning
+    `serialize` and `deepcopy` will not work with this codec due to stored raw pointers.
 """
 function ZlibDecompressor(;windowbits::Integer=Z_DEFAULT_WINDOWBITS)
     if !(8 ≤ windowbits ≤ 15)
@@ -78,6 +87,9 @@ const ZlibDecompressorStream{S} = TranscodingStream{ZlibDecompressor,S} where S<
     ZlibDecompressorStream(stream::IO; kwargs...)
 
 Create a deflate decompression stream (see `ZlibDecompressor` for `kwargs`).
+
+!!! warning
+    `serialize` and `deepcopy` will not work with this stream due to stored raw pointers.
 """
 function ZlibDecompressorStream(stream::IO; kwargs...)
     x, y = splitkwargs(kwargs, (:windowbits,))
@@ -101,6 +113,9 @@ Create a deflate decompression codec.
 Arguments
 ---------
 - `windowbits`: size of history buffer (8..15)
+
+!!! warning
+    `serialize` and `deepcopy` will not work with this codec due to stored raw pointers.
 """
 function DeflateDecompressor(;windowbits::Integer=Z_DEFAULT_WINDOWBITS)
     if !(8 ≤ windowbits ≤ 15)
@@ -115,6 +130,9 @@ const DeflateDecompressorStream{S} = TranscodingStream{DeflateDecompressor,S} wh
     DeflateDecompressorStream(stream::IO; kwargs...)
 
 Create a deflate decompression stream (see `DeflateDecompressor` for `kwargs`).
+
+!!! warning
+    `serialize` and `deepcopy` will not work with this stream due to stored raw pointers.
 """
 function DeflateDecompressorStream(stream::IO; kwargs...)
     x, y = splitkwargs(kwargs, (:windowbits,))


### PR DESCRIPTION
Related to issue #79