### PR TITLE
Add `Aqua` and `test_reuse_encoder` tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,4 +10,5 @@ Zlib_jll = "83775a58-1f1d-513f-b197-d71354ab007a"
 
 [compat]
 TranscodingStreams = "0.9, 0.10, 0.11"
+Zlib_jll = "1"
 julia = "1.6"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestsForCodecPackages = "c2e61002-3542-480d-8b3c-5f05cc4f8554"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using CodecZlib
 using Test
+using Aqua: Aqua
 using TranscodingStreams:
     TranscodingStreams,
     TranscodingStream
@@ -11,7 +12,10 @@ using TestsForCodecPackages:
     test_roundtrip_seekstart,
     test_roundtrip_fileio,
     test_chunked_read,
-    test_chunked_write
+    test_chunked_write,
+    test_reuse_encoder
+
+Aqua.test_all(CodecZlib)
 
 const testdir = @__DIR__
 
@@ -112,6 +116,7 @@ const testdir = @__DIR__
     test_roundtrip_lines(GzipCompressorStream, GzipDecompressorStream)
     test_roundtrip_seekstart(GzipCompressorStream, GzipDecompressorStream)
     test_roundtrip_transcode(GzipCompressor, GzipDecompressor)
+    test_reuse_encoder(GzipCompressor, GzipDecompressor)
 
     @test_throws ArgumentError GzipCompressor(level=10)
     @test_throws ArgumentError GzipCompressor(windowbits=16)
@@ -193,6 +198,7 @@ end
     test_roundtrip_lines(ZlibCompressorStream, ZlibDecompressorStream)
     test_roundtrip_seekstart(ZlibCompressorStream, ZlibDecompressorStream)
     test_roundtrip_transcode(ZlibCompressor, ZlibDecompressor)
+    test_reuse_encoder(ZlibCompressor, ZlibDecompressor)
 
     @test_throws ArgumentError ZlibCompressor(level=10)
     @test_throws ArgumentError ZlibCompressor(windowbits=16)
@@ -218,6 +224,7 @@ end
     test_roundtrip_lines(DeflateCompressorStream, DeflateDecompressorStream)
     test_roundtrip_seekstart(DeflateCompressorStream, DeflateDecompressorStream)
     test_roundtrip_transcode(DeflateCompressor, DeflateDecompressor)
+    test_reuse_encoder(DeflateCompressor, DeflateDecompressor)
 
     @test DeflateCompressorStream <: TranscodingStream
     @test DeflateDecompressorStream <: TranscodingStream


### PR DESCRIPTION
To get aqua tests to pass I have added a compat entry of `Zlib_jll = "1"` 