### PR TITLE
Add `ZlibError` type and move `initialize` into `startproc`

### DIFF
--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -174,7 +174,7 @@ function TranscodingStreams.startproc(codec::DecompressorCodec, ::Symbol, error_
         end
     else
         code = inflate_reset!(codec.zstream)
-        # errors in deflate_reset! do not require clean up, so just throw
+        # errors in inflate_reset! do not require clean up, so just throw
         if code == Z_OK
             return :ok
         elseif code == Z_STREAM_ERROR


### PR DESCRIPTION
This PR applies parts of https://github.com/JuliaIO/CodecBzip2.jl/pull/41 and https://github.com/JuliaIO/CodecZstd.jl/pull/74 to this package.

This PR turns the `initialize` function into a noop. The `startproc` function now automatically handles the initialization if the stream state is null.

Fixes #89 fixes #59 and partially fixes #48 (a future PR is required to prevent memory leaks)

For example, decompressing a truncated stream:
```julia-repl
julia> using CodecZlib

julia> transcode(ZlibDecompressor,UInt8[])
```

master:
```
ERROR: zlib error: <no message> (code: -5)
```

This PR:
```
ERROR: ZlibError: the compressed stream may be truncated
```