### PR TITLE
Bump version to 0.7.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "CodecZlib"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
 license = "MIT"
 authors = ["Kenta Sato <bicycle1885@gmail.com>"]
-version = "0.7.6"
+version = "0.7.7"
 
 [deps]
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"


### PR DESCRIPTION
diff: https://github.com/JuliaIO/CodecZlib.jl/compare/v0.7.6...aa46ccd4761993e53af7c119215797e322bd706a

This release bumps julia compat to v1.6.

It also adds a new `ZlibError` type. Ref #93

Lastly, the `windowbits` option now must be in `9:15` when compressing. Ref #60