### PR TITLE
Add finalizer to ZStream and make `TranscodingStreams.finalize` a noop

### DIFF
--- a/test/big-mem-tests.jl
+++ b/test/big-mem-tests.jl
@@ -6,16 +6,21 @@
 using Test
 using CodecZlib
 
-# Enable this when https://github.com/JuliaIO/CodecZlib.jl/issues/88 is fixed.
-# @testset "memory leak" begin
-#     function foo()
-#         for i in 1:1000000
-#             c = transcode(GzipCompressor(), zeros(UInt8,16))
-#             u = transcode(GzipDecompressor(), c)
-#         end
-#     end
-#     foo()
-# end
+@testset "memory leak" begin
+    function foo()
+        for (encode, decode) in [
+            (GzipCompressor, GzipDecompressor),
+            (ZlibCompressor, ZlibDecompressor),
+            (DeflateCompressor, DeflateDecompressor),
+        ]
+            for i in 1:1000000
+                c = transcode(encode(), zeros(UInt8,16))
+                u = transcode(decode(), c)
+            end
+        end
+    end
+    foo()
+end
 
 @testset "Big Memory Tests" begin
     Sys.WORD_SIZE == 64 || error("tests require 64 bit word size")


### PR DESCRIPTION
Fixes #48 and fixes #88 by porting https://github.com/JuliaIO/CodecBzip2.jl/pull/43 to this package.

According to https://www.zlib.net/manual.html#Basic
> If zlib is used in a multi-threaded application, zalloc and zfree must be thread safe. In that case, zlib is thread-safe. 

So, there shouldn't be any thread safety issues with the finalizer here.