### PR TITLE
Bump version to 0.7.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "CodecZlib"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
 license = "MIT"
 authors = ["Kenta Sato <bicycle1885@gmail.com>"]
-version = "0.7.7"
+version = "0.7.8"
 
 [deps]
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"


### PR DESCRIPTION
This release adds a finalizer to ZStream to prevent memory leaks. Ref: #97

This may cause performance regressions when allocating many codecs, but hopefully it will also be easier to reuse previously allocated codecs.